### PR TITLE
feat:🚩 添加设置参数：varTranslation.defaultFormat 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.13.34](https://github.com/SvenZhao/var-translation/compare/v0.13.33...v0.13.34) (2022-03-21)
+
+
+### Features
+
+* read ([9e28b01](https://github.com/SvenZhao/var-translation/commit/9e28b01eb50b474c587b645da1acce1cc4e836cf))
+* 新增多行选择翻译 ([e942063](https://github.com/SvenZhao/var-translation/commit/e9420638ee306a015a390d0d2a418a3bd398e84d))
+
 ### [0.13.33](https://github.com/SvenZhao/var-translation/compare/v0.13.32...v0.13.33) (2021-10-08)
 
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@
 可以在插件配置中Translation Engine中切换
 
 
+
 后续可能会通过申请key的方式接入官方的jsdk
 ```
+
+
+ ## 新增
+```
+  文案多选时可以依次翻译
+```
+
+
 [有问题直接报issue](https://github.com/SvenZhao/var-translation/issues) 
 ---
  ## 英文不好 写代起变量时候 你是否一直这样干?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "var-translation",
-  "version": "0.13.33",
+  "version": "0.13.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,37 @@
           ],
           "default": "google",
           "description": "翻译引擎"
+        },
+        "varTranslation.defaultFormat": {
+          "type": "string",
+          "enum": [
+            "camelCase",
+            "paramCase",
+            "pascalCase",
+            "snakeCase",
+            "constantCase",
+            "capitalCase",
+            "dotCase",
+            "headerCase",
+            "noCase",
+            "pathCase",
+            ""
+          ],
+          "enumDescriptions": [
+            "驼峰(小)",
+            "中划线(小)",
+            "驼峰(大)",
+            "下划线",
+            "常量",
+            "分词(大)",
+            "对象属性",
+            "中划线(大)",
+            "分词(小)",
+            "文件路径",
+            ""
+          ],
+          "default": "snakeCase",
+          "description": "下划线"
         }
       }
     }
@@ -85,16 +116,16 @@
     "@types/google-translate-api": "^2.3.1",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
-    "@types/vscode": "^1.50.0",
+    "@types/vscode": "^1.66.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
+    "@vscode/test-electron": "^2.1.3",
     "eslint": "^7.15.0",
     "glob": "^7.1.6",
     "mocha": "^8.1.3",
     "standard-version": "^9.1.0",
     "ts-loader": "^8.0.11",
     "typescript": "^4.1.2",
-    "vscode-test": "^1.4.1",
     "webpack": "^5.10.0",
     "webpack-cli": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "纠结怎么取变量? 中文一键翻译转换成常用大小驼峰等格式",
   "publisher": "svenzhao",
   "icon": "images/logo.png",
-  "version": "0.13.33",
+  "version": "0.13.34",
   "engines": {
     "vscode": "^1.50.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,19 +73,21 @@ async function main() {
     return;
   }
   // 获取选中文字
-  const { selection } = editor;
-  const selected = editor.document.getText(selection);
-  // 获取翻译结果
-  const translated = await getTranslateResult(selected);
-  if (!translated) {
-    return;
+  const { selections } = editor;
+  for (const selection of selections) {
+    const selected = editor.document.getText(selection);
+    // 获取翻译结果
+    const translated = await getTranslateResult(selected);
+    if (!translated) {
+      return;
+    }
+    // 组装选项
+    const userSelected = await vscodeSelect(translated);
+    // 用户选中
+    if (!userSelected) {
+      return;
+    }
+    // 替换文案
+    editor.edit((builder) => builder.replace(selection, userSelected));
   }
-  // 组装选项
-  const userSelected = await vscodeSelect(translated);
-  // 用户选中
-  if (!userSelected) {
-    return;
-  }
-  // 替换文案
-  editor.edit((builder) => builder.replace(selection, userSelected));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { window, ExtensionContext, commands, QuickPickItem, QuickPickOptions, workspace } from "vscode";
 import translatePlatforms, { EengineType } from "./inc/translate";
-
+import { FormatType } from "./inc/format";
 import {
   camelCase,
   paramCase,
@@ -66,6 +66,12 @@ async function getTranslateResult(srcText: string) {
     return null;
   }
 }
+
+async function getDefaultFormat() {
+  const type: FormatType = workspace.getConfiguration("varTranslation").defaultFormat;
+  return type;
+}
+
 async function main() {
   // 获取编辑器
   const editor = window.activeTextEditor;
@@ -82,7 +88,46 @@ async function main() {
       return;
     }
     // 组装选项
-    const userSelected = await vscodeSelect(translated);
+    let userSelected:any = null;
+    // 获取默认格式
+    const format = await getDefaultFormat();
+    if(format){
+      // userSelected = eval(`${format.toString()}(${selected})`);
+      switch(format.toString()){
+        case "camelCase":
+          userSelected=camelCase(selected);
+          break;
+        case "paramCase":
+          userSelected=paramCase(selected);
+          break;
+        case "pascalCase":
+          userSelected=pascalCase(selected);
+          break;
+        case "snakeCase":
+          userSelected=snakeCase(selected);
+          break;
+        case "constantCase":
+          userSelected=constantCase(selected);
+          break;
+        case "capitalCase":
+          userSelected=capitalCase(selected);
+          break;
+        case "dotCase":
+          userSelected=dotCase(selected);
+          break;
+        case "headerCase":
+          userSelected=headerCase(selected);
+          break;
+        case "noCase":
+          userSelected=noCase(selected);
+          break;
+        case "pathCase":
+          userSelected=pathCase(selected);
+          break;
+        }
+    }else{
+      userSelected = await vscodeSelect(translated);
+    }
     // 用户选中
     if (!userSelected) {
       return;

--- a/src/inc/format.ts
+++ b/src/inc/format.ts
@@ -1,0 +1,13 @@
+
+export enum FormatType {
+    camelCase,
+    paramCase,
+    pascalCase,
+    snakeCase,
+    constantCase,
+    capitalCase,
+    dotCase,
+    headerCase,
+    noCase,
+    pathCase
+  }


### PR DESCRIPTION
可以设置默认转换类型，提供枚举类型。
```
// settings.json file
// snakeCase | camelCase  etc ...
"var-translation.defalutFormat":"snakeCase"
```

我一开始用了master分支，测试了一下和develop合并没问题。

另外ts用的不好，枚举类型匹配函数名，类似反射用法，我是真的不会了... (╥╯^╰╥)。希望求教。