### PR TITLE
添加谷歌翻译顶级域名配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
           "default": "",
           "description": "腾讯翻译君密钥 使用逗号隔开例如 secretId,secretKey 申请地址看文档"
         },
+        "varTranslation.googleTld": {
+          "type": "string",
+          "default": "",
+          "description": "用于在调用API时使用的谷歌翻译的顶级域名:https://translate.google.{Tld} 默认为com"
+        },
         "varTranslation.translationEngine": {
           "type": "string",
           "enum": [

--- a/src/inc/translate.ts
+++ b/src/inc/translate.ts
@@ -16,7 +16,8 @@ export enum EengineType {
 }
 const engineType = {
   google: (src: string, to: string) => {
-    return google(src, { to, tld: "cn" });
+    const tld = workspace.getConfiguration("varTranslation").googleTld;
+    return google(src, { to, tld: tld==''?'com':tld });
   },
   baidu: async (src: string, to: string) => {
     const tokens = workspace.getConfiguration("varTranslation").baiduSecret.split(",");


### PR DESCRIPTION
在扩展设置中添加谷歌顶级域名的选项，默认为com域名
![image](https://user-images.githubusercontent.com/40168950/196674711-3d715a20-50bc-4598-bad8-ca0b45a145ec.png)
